### PR TITLE
Fixed alignment issues with some posts

### DIFF
--- a/hackernews.el
+++ b/hackernews.el
@@ -67,12 +67,21 @@
       'keymap map
       'mouse-face 'highlight))))
 
+
+(defun hackernews-space-fill (string n)
+  "Makes sure that string is at least n characters long, and
+   if it isn't, it adds SPACE-characters to the end"
+  (while (< (length string) n)
+    (setf string (concat string " ")))
+  (identity string))
+
 (defun hackernews-render-post (post)
   "Render a single post to the current buffer
 
 Add the post title as a link, and print the points and number of
 comments."
-  (princ (format "[%s]\t" (cdr (assoc 'points post))))
+  (princ (hackernews-space-fill 
+          (format "[%s]" (cdr (assoc 'points post))) 6))
   (hackernews-create-link-in-buffer
    (cdr (assoc 'title post))
    (cdr (assoc 'url post)))


### PR DESCRIPTION
If you have a look at [this screenshot](https://www.dropbox.com/s/86z6t3l385hu5i2/Screen%20Shot%202013-02-20%20at%208.45.11%20PM.png), you will notice the issue that I have been having. The posts that only have votes in the single digits, don't align properly to the right.

This pull request fixes this issue, as can be seen [here](https://www.dropbox.com/s/82ubri4kxbultrn/Screen%20Shot%202013-02-20%20at%208.49.49%20PM.png).
