### PR TITLE
add customization and fix keybinding

### DIFF
--- a/hackernews.el
+++ b/hackernews.el
@@ -34,6 +34,16 @@
 
 ;; "http://apihackernews.herokuapp.com/"
 
+(defgroup hackernews nil
+  "Simple hackernews emacs client"
+  :group 'external
+  :prefix "hackernews-")
+
+(defface hackernews-link-face
+  '((t (:foreground "green")))
+  "Face used for links to articles"
+  :group 'hackernews)
+
 (defvar hackernews-url "http://api.ihackernews.com/page"
   "The url to grab the list of news")
 
@@ -82,7 +92,7 @@
     (insert
      (propertize
       title
-      'face '(:foreground "green")
+      'face 'hackernews-link-face
       'keymap map
       'mouse-face 'highlight))))
 


### PR DESCRIPTION
Hello,

This fixes the `q` keybinding and all subsequent keybindings that may be added. The `if` in elisp is like a tertiary operator. If you don't use `progn`, the second line is considered the `else` clause. So it used to say: if there's a `hackernews-map` then add the `g` keybinding to it, otherwise add the `q` one. In fact, if you don't plan on having an `else` clause, I believe you can use `when` instead of `if`.

It also adds the possibility for users to customize the color of the links in the hackernews buffer. I have a light theme and `green` simply was unreadable.

Have a nice day!
Louis "Baboon" Kottmann
