### PR TITLE
Added support for text browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ the data.
 
 This version is able to list posts present in the main page, as well as
 their points and comment count. You can also click (or `RET`) in the
-post titles to open them in a browser.
+post titles to open them in a browser. 
+
+Or you can press 't' to open the article in text only mode in emacs itself. 
+It may not work for some articles due to the page structure.
 
 The next versions will implement the upvote command and the possibility
 to interact with comments.

--- a/hackernews.el
+++ b/hackernews.el
@@ -87,6 +87,8 @@
                 (map (make-sparse-keymap)))
     (define-key map (kbd "<RET>")
       #'(lambda (e) (interactive "p") (browse-url url)))
+    (define-key map (kbd "t")
+      #'(lambda (e) (interactive "p") (browse-url-text-emacs url)))
     (define-key map (kbd "<down-mouse-1>")
       #'(lambda (e) (interactive "p") (browse-url url)))
     (insert


### PR DESCRIPTION
Hey I have added the support to open the articles in emacs itself. Press 't' over the article and it will open the article. It opens the page using lynx. 
