### PR TITLE
Lisp aesthetics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 .DS_Store
+*.elc

--- a/hackernews.el
+++ b/hackernews.el
@@ -38,17 +38,17 @@
   :prefix "hackernews-")
 
 (defface hackernews-link-face
-  '((t (:foreground "green")))
+  '((t :foreground "green"))
   "Face used for links to articles."
   :group 'hackernews)
 
 (defface hackernews-comment-count-face
-  '((t (:foreground "green")))
+  '((t :inherit hackernews-link-face))
   "Face used for comment counts."
   :group 'hackernews)
 
 (defface hackernews-score-face
-  '((t (:foreground nil)))
+  '((t :inherit default))
   "Face used for the score of an article."
   :group 'hackernews)
 

--- a/hackernews.el
+++ b/hackernews.el
@@ -191,11 +191,12 @@ comments."
          (hackernews-link-of-url (hackernews-encoding url))
        (hackernews-comment-url id))
      'hackernews-link-face)
+    (insert ?\s)
     (hackernews-create-link-in-buffer
-     (format " (%d comments)" (length kids))
+     (format "(%d comments)" (length kids))
      (hackernews-comment-url id)
      'hackernews-comment-count-face)
-    (insert "\n")))
+    (insert ?\n)))
 
 (defun hackernews-format-results (results &optional append)
   "Create hackernews buffer to render RESULTS in.

--- a/hackernews.el
+++ b/hackernews.el
@@ -66,7 +66,18 @@ This should not exceed 100.")
 (defvar hackernews-item-url "https://hacker-news.firebaseio.com/v0/item/%s.json"
   "The URL format from which to grab an item's details.")
 
-(defvar hackernews-map (make-sparse-keymap)
+(defvar hackernews-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "g"             #'hackernews)
+    (define-key map "q"             #'quit-window)
+    (define-key map "m"             #'hackernews-load-more-stories)
+    (define-key map "n"             #'hackernews-next-item)
+    (define-key map "p"             #'hackernews-previous-item)
+    (define-key map "\t"            #'hackernews-next-comment)
+    (define-key map [backtab]       #'hackernews-previous-comment)
+    (define-key map [S-iso-lefttab] #'hackernews-previous-comment)
+    (define-key map [S-tab]         #'hackernews-previous-comment)
+    map)
   "The keymap to use with hackernews.")
 
 (defun hackernews-internal-browser (url)
@@ -107,16 +118,6 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
   (interactive)
   (forward-line -1)
   (hackernews-next-comment))
-
-(if hackernews-map
-    (progn
-      (define-key hackernews-map (kbd "g") 'hackernews)
-      (define-key hackernews-map (kbd "q") 'bury-buffer)
-      (define-key hackernews-map (kbd "m") 'hackernews-load-more-stories)
-      (define-key hackernews-map (kbd "n") 'hackernews-next-item)
-      (define-key hackernews-map (kbd "p") 'hackernews-previous-item)
-      (define-key hackernews-map (kbd "<tab>") 'hackernews-next-comment)
-      (define-key hackernews-map (kbd "<backtab>") 'hackernews-previous-comment)))
 
 ;;;###autoload
 (defun hackernews ()
@@ -162,11 +163,11 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
                 (url url)
                 (face face)
                 (map (make-sparse-keymap)))
-    (define-key map (kbd "<RET>")
+    (define-key map "\r"
       (lambda () (interactive) (browse-url url)))
-    (define-key map (kbd "t")
+    (define-key map "t"
       (lambda () (interactive) (hackernews-internal-browser url)))
-    (define-key map (kbd "<down-mouse-1>")
+    (define-key map [down-mouse-1]
       (lambda () (interactive) (browse-url url)))
     (insert
      (propertize

--- a/hackernews.el
+++ b/hackernews.el
@@ -147,11 +147,10 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
   (format "https://news.ycombinator.com/item?id=%s" id))
 
 (defun hackernews-link-of-url (url)
-  (lexical-let ((url url)
-		(hackernews-item "/comments/"))
-    (if (string-prefix-p hackernews-item url)
-	(hackernews-comment-url (substring url (length hackernews-item)))
-      url)))
+  (replace-regexp-in-string "\\`/comments/\\(.*\\)\\'"
+                            (lambda (match)
+                              (hackernews-comment-url (match-string 1 match)))
+                            url))
 
 (defun hackernews-create-link-in-buffer (title url face)
   "Insert clickable string into current buffer."

--- a/hackernews.el
+++ b/hackernews.el
@@ -208,12 +208,12 @@ buffer if available."
         (with-current-buffer buf
           (let ((inhibit-read-only t))
             (goto-char (point-max))
-            (mapcar 'hackernews-render-post results)))
+            (mapc #'hackernews-render-post results)))
       (with-output-to-temp-buffer buf-name
         (switch-to-buffer buf-name)
         (setq font-lock-mode nil)
         (use-local-map hackernews-map)
-        (mapcar 'hackernews-render-post results)))))
+        (mapc #'hackernews-render-post results)))))
 
 ;;; Retrieving and parsing
 

--- a/hackernews.el
+++ b/hackernews.el
@@ -154,9 +154,7 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
 
 (defun hackernews-create-link-in-buffer (title url face)
   "Insert clickable string into current buffer."
-  (lexical-let ((title title)
-                (url url)
-                (face face)
+  (lexical-let ((url url)
                 (map (make-sparse-keymap)))
     (define-key map "\r"
       (lambda () (interactive) (browse-url url)))

--- a/hackernews.el
+++ b/hackernews.el
@@ -221,12 +221,12 @@ buffer if available."
   "Get a list of stories.
 When specified, ignore all list entries after LIMIT and before
 OFFSET."
-  (if (null hackernews-top-story-list)
-      (setq hackernews-top-story-list
-            (append (hackernews-retrieve-and-parse hackernews-top-stories-url) nil)))
+  (unless hackernews-top-story-list
+    (setq hackernews-top-story-list
+          (append (hackernews-retrieve-and-parse hackernews-top-stories-url) ())))
   (let ((reverse-offset (- (length hackernews-top-story-list) (or offset 0))))
-    (if (<= reverse-offset 0)
-        (error "No more stories available"))
+    (when (<= reverse-offset 0)
+      (error "No more stories available"))
     (reverse (last (reverse (last hackernews-top-story-list reverse-offset)) limit))))
 
 (defun hackernews-get-item (id)
@@ -239,11 +239,11 @@ OFFSET."
   (let (json)
     (with-current-buffer (url-retrieve-synchronously url)
       (goto-char (point-min))
-      (when (not (string-match "200 OK" (buffer-string)))
+      (unless (string-match-p "200 OK" (buffer-string))
         (error "Problem connecting to the server"))
       (re-search-forward "^$" nil 'move)
       (setq json (buffer-substring-no-properties (point) (point-max)))
-      (kill-buffer (current-buffer)))
+      (kill-buffer))
     json))
 
 (defun hackernews-parse (contents)

--- a/hackernews.el
+++ b/hackernews.el
@@ -121,13 +121,12 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
 (defun hackernews ()
   "Read Hacker News."
   (interactive)
-  (setq hackernews-top-story-list nil)
-  (condition-case ex
+  (setq hackernews-top-story-list ())
+  (condition-case err
       (hackernews-format-results
-       (mapcar 'hackernews-get-item
+       (mapcar #'hackernews-get-item
                (hackernews-top-stories hackernews-top-story-limit)))
-    ('error
-     (message (format "hackernewsclient error: %s" (car (cdr ex))))))
+    (error (message "hackernews error: %s" (error-message-string err))))
   (hackernews-first-item))
 
 (defun hackernews-load-more-stories ()

--- a/hackernews.el
+++ b/hackernews.el
@@ -1,4 +1,4 @@
-;;; hackernews.el --- Hacker News Client for Emacs
+;;; hackernews.el --- Hacker News Client for Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012  Lincoln de Sousa <lincoln@comum.org>
 
@@ -163,11 +163,11 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
                 (face face)
                 (map (make-sparse-keymap)))
     (define-key map (kbd "<RET>")
-      #'(lambda (e) (interactive "p") (browse-url url)))
+      (lambda () (interactive) (browse-url url)))
     (define-key map (kbd "t")
-      #'(lambda (e) (interactive "p") (hackernews-internal-browser url)))
+      (lambda () (interactive) (hackernews-internal-browser url)))
     (define-key map (kbd "<down-mouse-1>")
-      #'(lambda (e) (interactive "p") (browse-url url)))
+      (lambda () (interactive) (browse-url url)))
     (insert
      (propertize
       title

--- a/hackernews.el
+++ b/hackernews.el
@@ -169,12 +169,6 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
       'keymap map
       'mouse-face 'highlight))))
 
-(defun hackernews-space-fill (string n)
-  "Ensure STRING has length at least N by padding with trailing spaces."
-  (while (< (length string) n)
-    (setf string (concat string " ")))
-  (identity string))
-
 (defun hackernews-encoding (string)
   "Encode STRING for hackernews."
   (decode-coding-string
@@ -189,11 +183,8 @@ comments."
         (url (cdr (assoc 'url post)))
         (score (cdr (assoc 'score post)))
         (kids (cdr (assoc 'kids post))))
-    (insert (hackernews-space-fill
-             (propertize
-              (format "[%s]" score)
-              'face 'hackernews-score-face)
-             6))
+    (insert (format "%-6s" (propertize (format "[%s]" score)
+                                       'face 'hackernews-score-face)))
     (hackernews-create-link-in-buffer
      (hackernews-encoding title)
      (if url

--- a/hackernews.el
+++ b/hackernews.el
@@ -178,11 +178,11 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
   "Render single hackernews POST in current buffer.
 Add POST title as a link and print its points and number of
 comments."
-  (let ((id (cdr (assoc 'id post)))
-        (title (cdr (assoc 'title post)))
-        (url (cdr (assoc 'url post)))
-        (score (cdr (assoc 'score post)))
-        (kids (cdr (assoc 'kids post))))
+  (let ((id    (cdr (assq 'id    post)))
+        (title (cdr (assq 'title post)))
+        (url   (cdr (assq 'url   post)))
+        (score (cdr (assq 'score post)))
+        (kids  (cdr (assq 'kids  post))))
     (insert (format "%-6s" (propertize (format "[%s]" score)
                                        'face 'hackernews-score-face)))
     (hackernews-create-link-in-buffer

--- a/hackernews.el
+++ b/hackernews.el
@@ -29,7 +29,6 @@
 
 (require 'json)
 (require 'url)
-(require 'eww nil :noerror)
 (eval-when-compile (require 'cl))
 
 (defgroup hackernews nil
@@ -83,7 +82,7 @@ This should not exceed 100.")
 (defun hackernews-internal-browser (url)
   "Open URL within Emacs.
 Try `eww' if available, otherwise `browse-url-text-browser'."
-  (if (featurep 'eww)
+  (if (fboundp 'eww-browse-url)
       (eww-browse-url url)
     (browse-url-text-emacs url)))
 

--- a/hackernews.el
+++ b/hackernews.el
@@ -97,20 +97,19 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
 (defun hackernews-next-item ()
   "Skip to next article link in hackernews buffer."
   (interactive)
-  (re-search-forward "^\[\[0-9]+\]\s*" nil t 1))
+  (re-search-forward "^\\[[[:digit:]]+][[:space:]]*" nil t))
 
 (defun hackernews-previous-item ()
   "Skip to previous article link in hackernews buffer."
   (interactive)
   (forward-line -1)
-  (beginning-of-line)
   (hackernews-next-item))
 
 (defun hackernews-next-comment ()
   "Skip to next article comments link in hackernews buffer."
   (interactive)
-  (re-search-forward " \([0-9]+ comments\)$" nil t 1)
-  (search-backward "("))
+  (when (re-search-forward " ([[:digit:]]+ comments)$" nil t)
+    (goto-char (1+ (match-beginning 0)))))
 
 (defun hackernews-previous-comment ()
   "Skip to previous article comments link in hackernews buffer."
@@ -138,10 +137,9 @@ Try `eww' if available, otherwise `browse-url-text-browser'."
                   hackernews-top-story-limit
                   (count-lines (point-min) (point-max)))))
     (hackernews-format-results
-     (mapcar 'hackernews-get-item stories)
+     (mapcar #'hackernews-get-item stories)
      t)
-    (forward-line (* (length stories) -1))
-    (beginning-of-line)
+    (forward-line (- (length stories)))
     (hackernews-next-item)))
 
 ;;; UI Functions


### PR DESCRIPTION
These changes:
* should be backward-compatible until at least Emacs 23;
* should not change any functionality of the package; and
* try to simplify or make more idiomatic the Lisp code itself.

I have tried to keep each commit as atomic and their message as descriptive as possible, so I recommend reviewing each one individually.