### PR TITLE
Delete hard-coded link foreground

### DIFF
--- a/hackernews.el
+++ b/hackernews.el
@@ -46,7 +46,7 @@
   'hackernews-link "0.4.0")
 
 (defface hackernews-link
-  '((t :inherit link :foreground "green" :underline nil))
+  '((t :inherit link :underline nil))
   "Face used for links to stories."
   :group 'hackernews)
 


### PR DESCRIPTION
Perhaps it is not the wisest decision to hard-code color of the link foreground because given `green` looks too bright for lighter themes such as `spacemacs-light` for example.

Otherwise, great package. Thank you for that!