### PR TITLE
Use native JSON support in Emacs 27

### DIFF
--- a/hackernews.el
+++ b/hackernews.el
@@ -405,16 +405,24 @@ their respective URLs."
 
 ;;; Retrieval
 
+(defalias 'hackernews--parse-json
+  (if (fboundp 'json-parse-buffer)
+      (lambda ()
+        (json-parse-buffer :object-type 'alist))
+    (lambda ()
+      (let ((json-object-type 'alist)
+            (json-array-type  'vector))
+        (json-read))))
+  "Read JSON object from current buffer starting at point.
+Objects are decoded as alists and arrays as vectors.")
+
 (defun hackernews-read-contents (url)
-  "Retrieve contents from URL and parse them as JSON.
-Objects are decoded as alists and arrays as vectors."
+  "Retrieve and read URL contents with `hackernews--parse-json'."
   (with-temp-buffer
-    (let ((json-object-type 'alist)
-          (json-array-type  'vector)
-          (url-show-status  (unless hackernews-suppress-url-status
-                              url-show-status)))
+    (let ((url-show-status (unless hackernews-suppress-url-status
+                             url-show-status)))
       (url-insert-file-contents url)
-      (json-read))))
+      (hackernews--parse-json))))
 
 (defun hackernews--retrieve-items (feed n ids &optional append)
   "Retrieve and render at most N new items from FEED.


### PR DESCRIPTION
Obviously URL retrieval completely overshadows JSON parsing as a performance bottleneck, but every little helps. Quoth `etc/NEWS`:

    The new configure option '--with-json' adds support for JSON using
    the Jansson library.  It is on by default; use 'configure
    --with-json=no' to build without Jansson support.  The new JSON
    functions 'json-serialize', 'json-insert', 'json-parse-string', and
    'json-parse-buffer' are typically much faster than their Lisp
    counterparts from json.el.