### PR TITLE
Handle json.el and url.el errors on older Emacsen

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,5 +1,5 @@
 ((nil
-  (bug-reference-bug-regexp . "\\(\\(?:issue\\|pr\\) ?\\)?#\\([[:digit:]]+\\)")
+  (bug-reference-bug-regexp . "\\(\\(?:issue\\|pr\\) ?\\)#\\([[:digit:]]+\\)")
   (bug-reference-url-format
    . "https://github.com/clarete/hackernews.el/issues/%s")
   (fill-column . 70)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ If you prefer to roll out your own Elisp, you could add to your
 (add-to-list 'same-window-regexps "\\`\\*hackernews .*\\*\\'")
 ```
 
+### Troubleshooting
+
+In general, errors and misbehavior pertaining to network retrieval and
+JSON parsing are probably due to bugs in older Emacsen.  The minimum
+recommended Emacs version for `hackernews` is 25.  Emacs 24 should
+work, but suffers from network security vulnerabilities that were
+fixed in version 25.
+
+A particularly annoying bug present in Emacs 23
+([bug#23750](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=23750))
+materializes in `hackernews` as a JSON readtable error.  You will know
+this is the case if the `hackernews` buffer contains stories titled
+`nil` and/or a `*Warnings*` buffer exists and lists relevant error
+messages.  The solution is to either upgrade to a newer Emacs version
+(recommended) or apply [Dmitry Gutov's
+patch](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=23750#95) in
+[bug#23750](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=23750) for
+the function `url-http-create-request` in `lisp/url/url-http.el` (not
+recommended).
+
 ## License
 
 Copyright (C) 2012-2018 Lincoln de Sousa <lincoln@comum.org>


### PR DESCRIPTION
It has always been a pain trying to get `hackernews` to work on Emacs 23 (read: it didn't work :), so I did some digging and found GNU Emacs [bug#23750](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=23750). This should affect all Emacsen prior to version 25, and yet I don't see it materialising in version 24. Perhaps some other bug fix made it less apparent in the interim.

In brief, bug#23750 results in `url-insert-file-contents` returning a truncated payload, which in turn causes `json-read` to choke. The details are in this patch and the Emacs bug report.

The fact that no-one has reported this yet, however, suggests that none of our users are running Emacs 23 (which I would very much like to think). So my main question is, is it finally time to drop Emacs 23 support? I'm not too bothered either way, but having Emacs 24 will make #40 a bit less of a pain as well. :)