### PR TITLE
Async preparations

### DIFF
--- a/hackernews.el
+++ b/hackernews.el
@@ -403,6 +403,11 @@ their respective URLs."
   (setq hackernews--feed-state ())
   (setq truncate-lines t)
   (buffer-disable-undo))
+
+(defun hackernews--ensure-major-mode ()
+  "Barf if current buffer is not derived from `hackernews-mode'."
+  (unless (derived-mode-p #'hackernews-mode)
+    (signal 'hackernews-error '("Not a hackernews buffer"))))
 
 ;;; Retrieval
 
@@ -500,6 +505,7 @@ and N defaults to `hackernews-items-per-page'."
   "Reload top N Hacker News stories from current feed.
 N defaults to `hackernews-items-per-page'."
   (interactive "P")
+  (hackernews--ensure-major-mode)
   (let ((feed (hackernews--get :feed)))
     (if feed
         (hackernews--load-stories feed n)
@@ -509,6 +515,7 @@ N defaults to `hackernews-items-per-page'."
   "Load N more stories into hackernews buffer.
 N defaults to `hackernews-items-per-page'."
   (interactive "P")
+  (hackernews--ensure-major-mode)
   (let ((feed   (hackernews--get :feed))
         (ids    (hackernews--get :ids))
         (offset (hackernews--get :offset)))

--- a/hackernews.el
+++ b/hackernews.el
@@ -524,14 +524,14 @@ End of feed; type \\[hackernews-reload] to load new items."))
 The Hacker News feed is determined by the user with completion
 and N defaults to `hackernews-items-per-page'."
   (interactive "P")
-  (let ((completion-extra-properties
-         (list :annotation-function #'hackernews--feed-annotation)))
-    (hackernews--load-stories
+  (hackernews--load-stories
+   (let ((completion-extra-properties
+          (list :annotation-function #'hackernews--feed-annotation)))
      (completing-read
       (format "Hacker News feed (default %s): " hackernews-default-feed)
       hackernews-feed-names nil t nil 'hackernews-feed-history
-      hackernews-default-feed)
-     n)))
+      hackernews-default-feed))
+   n))
 
 (defun hackernews-top-stories (&optional n)
   "Read top N Hacker News Top Stories.


### PR DESCRIPTION
This PR should not change any user-visible behaviour[1] and serves only to redesign how internal functions maintain and communicate state, both for the sake of cleaner design, but also with an eye to make #40 easier to implement.

The basic idea is to create the `hackernews` buffer upfront, so as to store state there sooner. The retrieval and rendering functions then need only refer to buffer-local variables, as opposed to those within scope. This is important because #40 may introduce multiple simultaneous retrievals of different feeds.

Please refer to each individual commit for details.

[1] Actually there is a minor bug fix included relating to `hackernews-preserve-point`; see the last commit.