### PR TITLE
Describe mode and button keymaps human-readably

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,18 @@ with comments.
 
 ### Keymap
 
-| Key              | Description                                 |
-|------------------|---------------------------------------------|
-| <kbd>RET</kbd>   | Open link in default (external) browser     |
-| <kbd>t</kbd>     | Open link in text-mode browser within Emacs |
-| <kbd>n</kbd>     | Move to next title link                     |
-| <kbd>p</kbd>     | Move to previous title link                 |
-| <kbd>TAB</kbd>   | Move to next comments count link            |
-| <kbd>S-TAB</kbd> | Move to previous comments count link        |
-| <kbd>m</kbd>     | Load more stories                           |
-| <kbd>g</kbd>     | Reload stories                              |
-| <kbd>f</kbd>     | Prompt user for a feed to switch to         |
-| <kbd>q</kbd>     | Quit                                        |
+| Key              | Description                                  |
+|------------------|----------------------------------------------|
+| <kbd>RET</kbd>   | Open link in default (external) browser      |
+| <kbd>t</kbd>     | Open link in text-based browser within Emacs |
+| <kbd>n</kbd>     | Move to next title link                      |
+| <kbd>p</kbd>     | Move to previous title link                  |
+| <kbd>TAB</kbd>   | Move to next comments count link             |
+| <kbd>S-TAB</kbd> | Move to previous comments count link         |
+| <kbd>m</kbd>     | Load more stories                            |
+| <kbd>g</kbd>     | Reload stories                               |
+| <kbd>f</kbd>     | Prompt user for a feed to switch to          |
+| <kbd>q</kbd>     | Quit                                         |
 
 All feed re/loading commands accept an optional [numeric prefix
 argument](https://www.gnu.org/software/emacs/manual/html_node/emacs/Arguments.html)

--- a/hackernews.el
+++ b/hackernews.el
@@ -426,18 +426,34 @@ their respective URLs."
 (define-derived-mode hackernews-mode special-mode "HN"
   "Mode for browsing Hacker News.
 
+Summary of key bindings:
+
+key		binding
+---		-------
 \\<hackernews-button-map>
-\\[push-button]	Open link in default (external) browser.
-\\[hackernews-button-browse-internal]	Open link in text-mode browser within Emacs.
+\\[push-button]\
+		Open link at point in default (external) browser.
+\\[hackernews-button-browse-internal]\
+		Open link at point in text-mode browser within Emacs.
 \\<hackernews-mode-map>
-\\[hackernews-next-item]	Move to next title link.
-\\[hackernews-previous-item]	Move to previous title link.
-\\[hackernews-next-comment]	Move to next comments count link.
-\\[hackernews-previous-comment]	Move to previous comments count link.
-\\[hackernews-load-more-stories]	Load more stories.
-\\[hackernews-reload]	Reload stories.
-\\[hackernews-switch-feed]	Prompt user for a feed to switch to.
-\\[quit-window]	Quit.
+\\[hackernews-next-item]\
+		Move to next title link.
+\\[hackernews-previous-item]\
+		Move to previous title link.
+\\[hackernews-next-comment]\
+		Move to next comments count link.
+\\[hackernews-previous-comment]\
+		Move to previous comments count link.
+\\[hackernews-load-more-stories]\
+		Load more stories.
+\\[hackernews-reload]\
+		Reload stories.
+\\[hackernews-switch-feed]\
+		Prompt user for a feed to switch to.
+\\[quit-window]\
+		Quit.
+
+Official major mode key bindings:
 
 \\{hackernews-mode-map}"
   :group 'hackernews

--- a/hackernews.el
+++ b/hackernews.el
@@ -426,6 +426,19 @@ their respective URLs."
 (define-derived-mode hackernews-mode special-mode "HN"
   "Mode for browsing Hacker News.
 
+\\<hackernews-button-map>
+\\[push-button]	Open link in default (external) browser.
+\\[hackernews-button-browse-internal]	Open link in text-mode browser within Emacs.
+\\<hackernews-mode-map>
+\\[hackernews-next-item]	Move to next title link.
+\\[hackernews-previous-item]	Move to previous title link.
+\\[hackernews-next-comment]	Move to next comments count link.
+\\[hackernews-previous-comment]	Move to previous comments count link.
+\\[hackernews-load-more-stories]	Load more stories.
+\\[hackernews-reload]	Reload stories.
+\\[hackernews-switch-feed]	Prompt user for a feed to switch to.
+\\[quit-window]	Quit.
+
 \\{hackernews-mode-map}"
   :group 'hackernews
   (setq hackernews--feed-state ())

--- a/hackernews.el
+++ b/hackernews.el
@@ -434,7 +434,7 @@ key		binding
 \\[push-button]\
 		Open link at point in default (external) browser.
 \\[hackernews-button-browse-internal]\
-		Open link at point in text-mode browser within Emacs.
+		Open link at point in text-based browser within Emacs.
 \\<hackernews-mode-map>
 \\[hackernews-next-item]\
 		Move to next title link.


### PR DESCRIPTION
Provide an overview of the most important key bindings when using `describe-mode`, similar to the keymap table in README.md.

Output:
~~~
RET	Open link in default (external) browser.
t	Open link in text-mode browser within Emacs.

n	Move to next title link.
p	Move to previous title link.
TAB	Move to next comments count link.
<S-tab>	Move to previous comments count link.
m	Load more stories.
g	Reload stories.
f	Prompt user for a feed to switch to.
q	Quit.
~~~