### PR TITLE
Keep track of visited links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ with comments.
 |------------------|----------------------------------------------|
 | <kbd>RET</kbd>   | Open link in default (external) browser      |
 | <kbd>t</kbd>     | Open link in text-based browser within Emacs |
+| <kbd>r</kbd>     | Mark link as visited.                        |
 | <kbd>n</kbd>     | Move to next title link                      |
 | <kbd>p</kbd>     | Move to previous title link                  |
 | <kbd>TAB</kbd>   | Move to next comments count link             |

--- a/hackernews.el
+++ b/hackernews.el
@@ -351,7 +351,7 @@ This is intended as an :annotation-function in
                     "Could not write `hackernews-visited-links-file': %s"
                     (error-message-string err))))))
 
-(defun hackernews-visited-ids-load ()
+(defun hackernews-visited-links-load ()
   "Read visited links from `hackernews-visited-links-file'."
   (when hackernews-visited-links-file
     (with-temp-buffer
@@ -371,8 +371,8 @@ This is intended as an :annotation-function in
 	       (cadr (assoc 'comment-ids in)))))
 	(error
 	 (lwarn 'hackernews :error
-	  "Could not read `hackernews-visited-links-file': %s"
-	  (error-message-string err)))))))
+		"Could not read `hackernews-visited-links-file': %s"
+		(error-message-string err)))))))
 
 (defalias 'hackernews--signum
   (if (and (require 'cl-lib nil t)
@@ -650,12 +650,14 @@ rendered at the end of the hackernews buffer."
 ;;; Feeds
 
 ;;;###autoload
+(setq hackernews--visited-links-loaded nil)
 (defun hackernews (&optional n)
   "Read top N Hacker News stories.
 The Hacker News feed is determined by `hackernews-default-feed'
 and N defaults to `hackernews-items-per-page'."
   (interactive "P")
-  (hackernews-visited-ids-load)
+  (if (not hackernews--visited-links-loaded)
+      (hackernews-visited-links-load))
   (hackernews--load-stories hackernews-default-feed n))
 
 (defun hackernews-reload (&optional n)

--- a/hackernews.el
+++ b/hackernews.el
@@ -462,7 +462,7 @@ N.B.  Any valid data in the file will be overwritten next time
                     (error-message-string err))))))
 
 (defun hackernews--visit (button fn)
-  "Visit URL of BUTTON by passing to to FN."
+  "Visit URL of BUTTON by passing it to FN."
   (let* ((id    (button-get button 'id))
          (type  (button-type button))
          (vtype (button-type-get type 'hackernews-visited-type))

--- a/hackernews.el
+++ b/hackernews.el
@@ -614,7 +614,7 @@ rendered at the end of the hackernews buffer."
     (dolist (entry hackernews--visited-ids)
       (setcdr entry (make-hash-table)))
     (hackernews-visited-links-load)
-    (add-hook 'kill-emacs-hook #'hackernews-save-visited-links))
+    (add-hook 'kill-emacs-hook #'hackernews-visited-links-save))
 
   (let* ((name   (hackernews--feed-name feed))
          (offset (or (car append) 0))

--- a/hackernews.el
+++ b/hackernews.el
@@ -378,23 +378,23 @@ N defaults to 1."
 
 (defun hackernews-browse-url-action (button)
   "Pass URL of BUTTON to `browse-url'."
-  (let ((id (button-get (button-at (point)) 'id))
-	(url (button-get (button-at (point)) 'shr-url))
-	(button-type (button-get (button-at (point)) 'type)))
+  (let ((id (button-get button 'id))
+	(url (button-get button 'shr-url))
+	(button-type (button-get button 'type)))
     (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids))))
   (browse-url (button-get button 'shr-url)))
 
-(defun hackernews-button-browse-internal ()
+(defun hackernews-button-browse-internal (button)
   "Open URL of button under point within Emacs.
 The URL is passed to `hackernews-internal-browser-function',
 which see."
   (interactive)
-  (let ((id (button-get (button-at (point)) 'id))
-	(url (button-get (button-at (point)) 'shr-url))
-	(button-type (button-get (button-at (point)) 'type)))
+  (let ((id (button-get button 'id))
+	(url (button-get button 'shr-url))
+	(button-type (button-get button 'type)))
     (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids))))
   (funcall hackernews-internal-browser-function
-           (button-get (point) 'shr-url)))
+           (button-get button 'shr-url)))
 
 (defun hackernews--button-string (type label url id)
   "Return button string of TYPE pointing to URL with LABEL."

--- a/hackernews.el
+++ b/hackernews.el
@@ -199,6 +199,13 @@ See `browse-url-browser-function' for some possible options."
   :group 'hackernews
   :type (cons 'radio (butlast (cdr (custom-variable-type
                                     'browse-url-browser-function)))))
+
+(defcustom hackernews-show-visited t
+  "Whether to distinguish the appearance of visited links with a
+  distinct face."
+  :package-version '(hackernews . "0.5.0")
+  :group 'hackernews
+  :type 'boolean)
 
 ;;; Internal definitions
 
@@ -383,8 +390,9 @@ N defaults to 1."
 	  (url (bget 'shr-url))
 	  (button-type (bget 'type)))
       (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids)))
-      (let ((inhibit-read-only t))
-	(button-put button 'type 'hackernews-link-visited))
+      (if hackernews-show-visited
+	  (let ((inhibit-read-only t))
+	    (button-put button 'type 'hackernews-link-visited)))
       (browse-url url))))
 
 (defun hackernews-button-browse-internal (button)
@@ -397,8 +405,9 @@ which see."
 	  (url (bget 'shr-url))
 	  (button-type (bget 'type)))
       (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids)))
-      (let ((inhibit-read-only t))
-	(button-put button 'type 'hackernews-comment-count-visited))
+      (if hackernews-show-visited
+	  (let ((inhibit-read-only t))
+	    (button-put button 'type 'hackernews-comment-count-visited)))
       (funcall hackernews-internal-browser-function url))))
 
 (defun hackernews--button-string (type label url id)
@@ -427,14 +436,14 @@ their respective URLs."
                    ?s (propertize (format hackernews-score-format score)
                                   'face 'hackernews-score)
                    ?t (hackernews--button-string
-                       (if (member id (button-type-get 'hackernews-link 'hackernews-visited-ids))
+                       (if (and hackernews-show-visited (member id (button-type-get 'hackernews-link 'hackernews-visited-ids)))
 			   'hackernews-link-visited
 			 'hackernews-link)
                        (format hackernews-title-format title)
                        (or item-url comments-url)
 		       id)
                    ?c (hackernews--button-string
-		       (if (member id (button-type-get 'hackernews-comment-count 'hackernews-visited-ids))
+		       (if (and hackernews-show-visited (member id (button-type-get 'hackernews-comment-count 'hackernews-visited-ids)))
 			   'hackernews-comment-count-visited
 			 'hackernews-comment-count)
                        (format hackernews-comments-format (or descendants 0))

--- a/hackernews.el
+++ b/hackernews.el
@@ -267,20 +267,20 @@ When nil, visited links are not persisted across sessions."
   "Keymap used on hackernews links.")
 
 (define-button-type 'hackernews-link
-  'action                    #'hackernews-browse-url-action
-  'face                      'hackernews-link
-  'follow-link               t
-  'hackernews-visited-button 'hackernews-link-visited
-  'keymap                    hackernews-button-map)
+  'action                  #'hackernews-browse-url-action
+  'face                    'hackernews-link
+  'follow-link             t
+  'hackernews-visited-type 'hackernews-link-visited
+  'keymap                  hackernews-button-map)
 
 (define-button-type 'hackernews-link-visited
   'face      'hackernews-link-visited
   'supertype 'hackernews-link)
 
 (define-button-type 'hackernews-comment-count
-  'face                      'hackernews-comment-count
-  'hackernews-visited-button 'hackernews-comment-count-visited
-  'supertype                 'hackernews-link)
+  'face                    'hackernews-comment-count
+  'hackernews-visited-type 'hackernews-comment-count-visited
+  'supertype               'hackernews-link)
 
 ;; Remove `hackernews-link' as `supertype' so that
 ;; `hackernews--forward-button' can distinguish between
@@ -427,7 +427,7 @@ N defaults to 1."
 (defun hackernews--visit (button fn)
   "Visit URL of BUTTON by passing to to FN."
   (let* ((type  (button-type button))
-         (vtype (button-type-get type 'hackernews-visited-button))
+         (vtype (button-type-get type 'hackernews-visited-type))
          (inhibit-read-only t))
     (when (and hackernews-show-visited-links
                (not (eq type vtype)))
@@ -450,12 +450,12 @@ which see."
 
 (defun hackernews--button-string (type label url id)
   "Return button string of TYPE pointing to URL with LABEL.
-Replace TYPE with the value of its `hackernews-visited-button'
+Replace TYPE with the value of its `hackernews-visited-type'
 property if `hackernews-show-visited-links' is non-nil and a
 button with TYPE and ID is known to have been visited."
   (and hackernews-show-visited-links
        (gethash id (cdr (assq type hackernews--visited-ids)))
-       (setq type (button-type-get type 'hackernews-visited-button)))
+       (setq type (button-type-get type 'hackernews-visited-type)))
   (make-text-button label nil 'type type 'help-echo url 'shr-url url 'id id)
   label)
 

--- a/hackernews.el
+++ b/hackernews.el
@@ -447,19 +447,19 @@ N defaults to 1."
 	    (button-put button 'type 'hackernews-link-visited)))
       (browse-url url))))
 
-(defun hackernews-button-browse-internal (button)
+(defun hackernews-button-browse-internal ()
   "Open URL of button under point within Emacs.
 The URL is passed to `hackernews-internal-browser-function',
 which see."
   (interactive)
-  (flet ((bget (prop) (button-get button prop)))
+  (flet ((bget (prop) (button-get (button-at (point)) prop)))
     (let ((id (bget 'id))
 	  (url (bget 'shr-url))
 	  (button-type (bget 'type)))
       (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids)))
       (if hackernews-show-visited-links
 	  (let ((inhibit-read-only t))
-	    (button-put button 'type 'hackernews-comment-count-visited)))
+	    (button-put (button-at (point)) 'type 'hackernews-comment-count-visited)))
       (funcall hackernews-internal-browser-function url))))
 
 (defun hackernews--button-string (type label url id)

--- a/hackernews.el
+++ b/hackernews.el
@@ -379,10 +379,9 @@ N defaults to 1."
 (defun hackernews-browse-url-action (button)
   "Pass URL of BUTTON to `browse-url'."
   (let ((id (button-get (button-at (point)) 'id))
-	(url (button-get (button-at (point)) 'shr-url)))
-    (if (string-match-p (regexp-quote "ycombinator") url)
-	(add-to-list 'hackernews--visited-comment-ids id)
-      (add-to-list 'hackernews--visited-article-ids id)))
+	(url (button-get (button-at (point)) 'shr-url))
+	(button-type (button-get (button-at (point)) 'type)))
+    (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids))))
   (browse-url (button-get button 'shr-url)))
 
 (defun hackernews-button-browse-internal ()
@@ -391,10 +390,9 @@ The URL is passed to `hackernews-internal-browser-function',
 which see."
   (interactive)
   (let ((id (button-get (button-at (point)) 'id))
-	(url (button-get (button-at (point)) 'shr-url)))
-    (if (string-match-p (regexp-quote "ycombinator") url)
-	(add-to-list 'hackernews--visited-comment-ids id)
-      (add-to-list 'hackernews--visited-article-ids id)))
+	(url (button-get (button-at (point)) 'shr-url))
+	(button-type (button-get (button-at (point)) 'type)))
+    (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids))))
   (funcall hackernews-internal-browser-function
            (button-get (point) 'shr-url)))
 
@@ -424,12 +422,12 @@ their respective URLs."
                    ?s (propertize (format hackernews-score-format score)
                                   'face 'hackernews-score)
                    ?t (hackernews--button-string
-                       (if (member id hackernews--visited-article-ids) 'hackernews-link-visited 'hackernews-link)
+                       (if (member id (button-type-get 'hackernews-link 'hackernews-visited-ids)) 'hackernews-link-visited 'hackernews-link)
                        (format hackernews-title-format title)
                        (or item-url comments-url)
 		       id)
                    ?c (hackernews--button-string
-		       (if (member id hackernews--visited-comment-ids) 'hackernews-link-visited 'hackernews-link)
+		       (if (member id (button-type-get 'hackernews-comment-count 'hackernews-visited-ids)) 'hackernews-comment-count-visited 'hackernews-comment-count)
                        (format hackernews-comments-format (or descendants 0))
                        comments-url
 		       id))))))

--- a/hackernews.el
+++ b/hackernews.el
@@ -293,7 +293,8 @@ When nil, visited links are not persisted across sessions."
 
 (defvar hackernews--visited-ids '((hackernews-link)
                                   (hackernews-comment-count))
-  "Map link button types to their visited ID sets.")
+  "Map link button types to their visited ID sets.
+Values are initially nil and later replaced with a hash table.")
 
 ;; Emulate `define-error'
 (put 'hackernews-error 'error-conditions '(hackernews-error error))

--- a/hackernews.el
+++ b/hackernews.el
@@ -250,27 +250,26 @@ See `browse-url-browser-function' for some possible options."
   "Keymap used on hackernews links.")
 
 (define-button-type 'hackernews-link
-  'action      #'hackernews-browse-url-action
-  'face        'hackernews-link
-  'follow-link t
-  'keymap      hackernews-button-map)
+  'action                    #'hackernews-browse-url-action
+  'face                      'hackernews-link
+  'follow-link               t
+  'hackernews-visited-ids    '()
+  'hackernews-visited-button 'hackernews-link-visited
+  'keymap                    hackernews-button-map)
 
 (define-button-type 'hackernews-link-visited
-  'action      #'hackernews-browse-url-action
-  'face        'hackernews-link-visited
-  'follow-link t
-  'keymap      hackernews-button-map)
+  'face      'hackernews-link-visited
+  'supertype 'hackernews-link)
 
 (define-button-type 'hackernews-comment-count
-  'face      'hackernews-comment-count
-  'supertype 'hackernews-link)
+  'face                      'hackernews-comment-count
+  'hackernews-visited-ids    '()
+  'hackernews-visited-button 'hackernews-comment-count-visited
+  'supertype                 'hackernews-link)
 
 (define-button-type 'hackernews-comment-count-visited
-  'face      'hackernews-comment-count
-  'supertype 'hackernews-link)
-
-(defvar hackernews--visited-article-ids '())
-(defvar hackernews--visited-comment-ids '())
+  'face      'hackernews-comment-count-visited
+  'supertype 'hackernews-comment-count)
 
 ;; Emulate `define-error'
 (put 'hackernews-error 'error-conditions '(hackernews-error error))

--- a/hackernews.el
+++ b/hackernews.el
@@ -340,31 +340,6 @@ This is intended as an :annotation-function in
   (let ((name (hackernews--feed-name feed)))
     (and name (concat " - " name))))
 
-(defun hackernews-visited-links-save ()
-  "Write visited links to `hackernews-visited-links-file'."
-  (when hackernews-visited-links-file
-    (condition-case err
-        (with-temp-file hackernews-visited-links-file
-          (let ((dir (file-name-directory hackernews-visited-links-file)))
-            ;; Ensure any parent directories exist
-            (when dir (make-directory dir t)))
-          (prin1 hackernews--visited-ids (current-buffer)))
-      (error (lwarn 'hackernews :error
-                    "Could not write `hackernews-visited-links-file': %s"
-                    (error-message-string err))))))
-
-(defun hackernews-visited-links-load ()
-  "Read visited links from `hackernews-visited-links-file'."
-  (and hackernews-visited-links-file
-       (file-exists-p hackernews-visited-links-file)
-       (condition-case err
-           (with-temp-buffer
-             (insert-file-contents hackernews-visited-links-file)
-             (setq hackernews--visited-ids (read (current-buffer))))
-         (error (lwarn 'hackernews :error
-                       "Could not read `hackernews-visited-links-file': %s"
-                       (error-message-string err))))))
-
 (defalias 'hackernews--signum
   (if (and (require 'cl-lib nil t)
            (fboundp 'cl-signum))
@@ -424,6 +399,31 @@ N defaults to 1."
   (hackernews-next-item))
 
 ;;; UI
+
+(defun hackernews-visited-links-save ()
+  "Write visited links to `hackernews-visited-links-file'."
+  (when hackernews-visited-links-file
+    (condition-case err
+        (with-temp-file hackernews-visited-links-file
+          (let ((dir (file-name-directory hackernews-visited-links-file)))
+            ;; Ensure any parent directories exist
+            (when dir (make-directory dir t)))
+          (prin1 hackernews--visited-ids (current-buffer)))
+      (error (lwarn 'hackernews :error
+                    "Could not write `hackernews-visited-links-file': %s"
+                    (error-message-string err))))))
+
+(defun hackernews-visited-links-load ()
+  "Read visited links from `hackernews-visited-links-file'."
+  (and hackernews-visited-links-file
+       (file-exists-p hackernews-visited-links-file)
+       (condition-case err
+           (with-temp-buffer
+             (insert-file-contents hackernews-visited-links-file)
+             (setq hackernews--visited-ids (read (current-buffer))))
+         (error (lwarn 'hackernews :error
+                       "Could not read `hackernews-visited-links-file': %s"
+                       (error-message-string err))))))
 
 (defun hackernews--visit (button fn)
   "Visit URL of BUTTON by passing to to FN."

--- a/hackernews.el
+++ b/hackernews.el
@@ -209,7 +209,7 @@ face is changed to `hackernews-link-visited'."
   :group 'hackernews
   :type 'boolean)
 
-(defcustom hackernews-visited-links-file (locate-user-emacs-file "/hackernews/visited-links.el")
+(defcustom hackernews-visited-links-file (locate-user-emacs-file "hackernews/visited-links.el")
   "Name of file used to remember which links have been visited.
 When nil, visited links are not persisted across sessions."
   :package-version '(hackernews . "0.5.0")

--- a/hackernews.el
+++ b/hackernews.el
@@ -400,6 +400,13 @@ N defaults to 1."
 
 ;;; UI
 
+(defun hackernews--init-visited-links ()
+  "Set up tracking of visited links.
+Do nothing if `hackernews--visited-ids' is already initialized."
+  (unless (cdar hackernews--visited-ids)
+    (hackernews-load-visited-links)
+    (add-hook 'kill-emacs-hook #'hackernews-save-visited-links)))
+
 (defun hackernews-load-visited-links ()
   "Merge visited links on file with those in memory.
 This command tries to reread `hackernews-visited-links-file',
@@ -632,12 +639,7 @@ off.  At most N of FEED's items starting at OFFSET are then
 rendered at the end of the hackernews buffer."
   ;; TODO: * Allow negative N?
   ;;       * Make asynchronous?
-
-  ;; Ensure visited links are set up
-  (unless (cdar hackernews--visited-ids)
-    (hackernews-load-visited-links)
-    (add-hook 'kill-emacs-hook #'hackernews-save-visited-links))
-
+  (hackernews--init-visited-links)
   (let* ((name   (hackernews--feed-name feed))
          (offset (or (car append) 0))
          (ids    (if append

--- a/hackernews.el
+++ b/hackernews.el
@@ -263,6 +263,7 @@ When nil, visited links are not persisted across sessions."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map button-map)
     (define-key map "t" #'hackernews-button-browse-internal)
+    (define-key map "r" #'hackernews-button-mark-as-visited)
     map)
   "Keymap used on hackernews links.")
 
@@ -489,6 +490,11 @@ The URL is passed to `hackernews-internal-browser-function',
 which see."
   (interactive)
   (hackernews--visit (point) hackernews-internal-browser-function))
+
+(defun hackernews-button-mark-as-visited ()
+  "Mark button under point as visited."
+  (interactive)
+  (hackernews--visit (point) 'ignore))
 
 (defun hackernews--button-string (type label url id)
   "Return button string of TYPE pointing to URL with LABEL.

--- a/hackernews.el
+++ b/hackernews.el
@@ -209,7 +209,8 @@ face is changed to `hackernews-link-visited'."
   :group 'hackernews
   :type 'boolean)
 
-(defcustom hackernews-visited-links-file (locate-user-emacs-file "hackernews/visited-links.el")
+(defcustom hackernews-visited-links-file
+  (locate-user-emacs-file "hackernews/visited-links.el")
   "Name of file used to remember which links have been visited.
 When nil, visited links are not persisted across sessions."
   :package-version '(hackernews . "0.5.0")
@@ -272,7 +273,7 @@ When nil, visited links are not persisted across sessions."
   'action                    #'hackernews-browse-url-action
   'face                      'hackernews-link
   'follow-link               t
-  'hackernews-visited-ids    '()
+  'hackernews-visited-ids    ()
   'hackernews-visited-button 'hackernews-link-visited
   'keymap                    hackernews-button-map)
 
@@ -282,7 +283,7 @@ When nil, visited links are not persisted across sessions."
 
 (define-button-type 'hackernews-comment-count
   'face                      'hackernews-comment-count
-  'hackernews-visited-ids    '()
+  'hackernews-visited-ids    ()
   'hackernews-visited-button 'hackernews-comment-count-visited
   'supertype                 'hackernews-link)
 
@@ -383,7 +384,6 @@ This is intended as an :annotation-function in
             ((< x 0) -1)
             (t        0))))
   "Compatibility shim for `cl-signum'.")
-
 
 ;;; Motion
 

--- a/hackernews.el
+++ b/hackernews.el
@@ -383,6 +383,8 @@ N defaults to 1."
 	  (url (bget 'shr-url))
 	  (button-type (bget 'type)))
       (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids)))
+      (let ((inhibit-read-only t))
+	(button-put button 'type 'hackernews-link-visited))
       (browse-url url))))
 
 (defun hackernews-button-browse-internal (button)
@@ -395,6 +397,8 @@ which see."
 	  (url (bget 'shr-url))
 	  (button-type (bget 'type)))
       (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids)))
+      (let ((inhibit-read-only t))
+	(button-put button 'type 'hackernews-comment-count-visited))
       (funcall hackernews-internal-browser-function url))))
 
 (defun hackernews--button-string (type label url id)

--- a/hackernews.el
+++ b/hackernews.el
@@ -217,7 +217,7 @@ When nil, visited links are not persisted across sessions."
   :type '(choice file (const :tag "None" nil)))
 
 (unless noninteractive
-  (add-hook 'kill-emacs-hook 'hackernews-visited-ids-save))
+  (add-hook 'kill-emacs-hook 'hackernews-visited-links-save))
 
 ;;; Internal definitions
 

--- a/hackernews.el
+++ b/hackernews.el
@@ -423,12 +423,16 @@ their respective URLs."
                    ?s (propertize (format hackernews-score-format score)
                                   'face 'hackernews-score)
                    ?t (hackernews--button-string
-                       (if (member id (button-type-get 'hackernews-link 'hackernews-visited-ids)) 'hackernews-link-visited 'hackernews-link)
+                       (if (member id (button-type-get 'hackernews-link 'hackernews-visited-ids))
+			   'hackernews-link-visited
+			 'hackernews-link)
                        (format hackernews-title-format title)
                        (or item-url comments-url)
 		       id)
                    ?c (hackernews--button-string
-		       (if (member id (button-type-get 'hackernews-comment-count 'hackernews-visited-ids)) 'hackernews-comment-count-visited 'hackernews-comment-count)
+		       (if (member id (button-type-get 'hackernews-comment-count 'hackernews-visited-ids))
+			   'hackernews-comment-count-visited
+			 'hackernews-comment-count)
                        (format hackernews-comments-format (or descendants 0))
                        comments-url
 		       id))))))

--- a/hackernews.el
+++ b/hackernews.el
@@ -378,23 +378,24 @@ N defaults to 1."
 
 (defun hackernews-browse-url-action (button)
   "Pass URL of BUTTON to `browse-url'."
-  (let ((id (button-get button 'id))
-	(url (button-get button 'shr-url))
-	(button-type (button-get button 'type)))
-    (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids))))
-  (browse-url (button-get button 'shr-url)))
+  (flet ((bget (prop) (button-get button prop)))
+    (let ((id (bget 'id))
+	  (url (bget 'shr-url))
+	  (button-type (bget 'type)))
+      (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids)))
+      (browse-url url))))
 
 (defun hackernews-button-browse-internal (button)
   "Open URL of button under point within Emacs.
 The URL is passed to `hackernews-internal-browser-function',
 which see."
   (interactive)
-  (let ((id (button-get button 'id))
-	(url (button-get button 'shr-url))
-	(button-type (button-get button 'type)))
-    (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids))))
-  (funcall hackernews-internal-browser-function
-           (button-get button 'shr-url)))
+  (flet ((bget (prop) (button-get button prop)))
+    (let ((id (bget 'id))
+	  (url (bget 'shr-url))
+	  (button-type (bget 'type)))
+      (button-type-put button-type 'hackernews-visited-ids (cons id (button-type-get button-type 'hackernews-visited-ids)))
+      (funcall hackernews-internal-browser-function url))))
 
 (defun hackernews--button-string (type label url id)
   "Return button string of TYPE pointing to URL with LABEL."

--- a/hackernews.el
+++ b/hackernews.el
@@ -494,7 +494,7 @@ which see."
 (defun hackernews-button-mark-as-visited ()
   "Mark button under point as visited."
   (interactive)
-  (hackernews--visit (point) 'ignore))
+  (hackernews--visit (point) #'ignore))
 
 (defun hackernews--button-string (type label url id)
   "Return button string of TYPE pointing to URL with LABEL.


### PR DESCRIPTION
This keeps track of visited item IDs, and differentiates visited links with faces.

Links are persisted to `hackernews-visited-ids-file`.

Closes #33.