### PR TITLE
Update Author and Maintainer headers

### DIFF
--- a/hackernews.el
+++ b/hackernews.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2012-2018 Lincoln de Sousa <lincoln@comum.org>
 
 ;; Author: Lincoln de Sousa <lincoln@comum.org>
-;;         Basil L. Contovounesios <contovob@tcd.ie>
+;; Maintainer: Basil L. Contovounesios <contovob@tcd.ie>
 ;; Keywords: comm hypermedia news
 ;; Version: 0.4.0
 ;; Homepage: https://github.com/clarete/hackernews.el


### PR DESCRIPTION
Re: #31.

Do you think this change makes sense @clarete? Here are the relevant header descriptions from [`(elisp) Library Headers`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html):

    ‘Author’
         This line states the name and email address of at least the
         principal author of the library.  If there are multiple authors,
         list them on continuation lines led by ‘;;’ and a tab or at least
         two spaces.  We recommend including a contact email address, of the
         form ‘<...>’.  For example:

              ;; Author: Your Name <yourname@example.com>
              ;;      Someone Else <someone@example.com>
              ;;      Another Person <another@example.com>

    ‘Maintainer’
         This header has the same format as the Author header.  It lists the
         person(s) who currently maintain(s) the file (respond to bug
         reports, etc.).

         If there is no maintainer line, the person(s) in the Author field
         is/are presumed to be the maintainers.  Some files in Emacs use
         ‘FSF’ for the maintainer.  This means that the original author is
         no longer responsible for the file, and that it is maintained as
         part of Emacs.