### PR TITLE
Remove stale badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,3 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-[![instanc.es Badge](https://instanc.es/bin/clarete/hackernews.el.png)](http://instanc.es)
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/clarete/hackernews.el/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
The `instanc.es` domain is no longer registered, `bitdeli.com` is down, and `@Bitdeli` hasn't been active on Twitter in over 4 years.

Re: #2.