### PR TITLE
Touch-up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 EMACS   ?= emacs
 PACKAGE  = hackernews
-VERSION ?= git
-TARGET   = $(PACKAGE)-$(VERSION)
 RM      ?= rm -f
 
 %.elc: %.el
@@ -11,16 +9,9 @@ all: lisp
 
 help:
 	$(info Available options)
-	$(info - package : Create a tar archive)
 	$(info - clean   : Clean the build directory)
 	$(info - emacs-Q : Launch emacs -Q with Hackernews loaded)
 	$(info - lisp    : Byte-compile Elisp sources)
-
-package:
-	mkdir -p $(TARGET)
-	cp hackernews.el hackernews-pkg.el README.md Screenshot.png COPYING $(TARGET)
-	tar cf $(TARGET).tar $(TARGET)
-	$(RM) -r $(TARGET)
 
 emacs-Q:
 	$(EMACS) --quick --load=$(PACKAGE).el
@@ -28,4 +19,4 @@ emacs-Q:
 lisp: $(PACKAGE).elc
 
 clean:
-	$(RM) $(PACKAGE).elc $(PACKAGE)-*.tar
+	$(RM) $(PACKAGE).elc

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+EMACS   ?= emacs
 PACKAGE  = hackernews
 VERSION ?= git
 TARGET   = $(PACKAGE)-$(VERSION)
@@ -7,6 +8,7 @@ help:
 	$(info Available options)
 	$(info - package : Create a tar archive)
 	$(info - clean   : Clean the build directory)
+	$(info - emacs-Q : Launch emacs -Q with Hackernews loaded)
 
 all: package
 
@@ -15,6 +17,9 @@ package:
 	cp hackernews.el hackernews-pkg.el README.md Screenshot.png COPYING $(TARGET)
 	tar cf $(TARGET).tar $(TARGET)
 	$(RM) -r $(TARGET)
+
+emacs-Q:
+	$(EMACS) --quick --load=$(PACKAGE).el
 
 clean:
 	$(RM) $(PACKAGE)-*.tar

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,17 @@ VERSION ?= git
 TARGET   = $(PACKAGE)-$(VERSION)
 RM      ?= rm -f
 
+%.elc: %.el
+	$(EMACS) --quick --batch --funcall=batch-byte-compile $<
+
+all: lisp
+
 help:
 	$(info Available options)
 	$(info - package : Create a tar archive)
 	$(info - clean   : Clean the build directory)
 	$(info - emacs-Q : Launch emacs -Q with Hackernews loaded)
-
-all: package
+	$(info - lisp    : Byte-compile Elisp sources)
 
 package:
 	mkdir -p $(TARGET)
@@ -21,5 +25,7 @@ package:
 emacs-Q:
 	$(EMACS) --quick --load=$(PACKAGE).el
 
+lisp: $(PACKAGE).elc
+
 clean:
-	$(RM) $(PACKAGE)-*.tar
+	$(RM) $(PACKAGE).elc $(PACKAGE)-*.tar

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EMACS   ?= emacs
-PACKAGE  = hackernews
+PACKAGE := hackernews
 RM      ?= rm -f
 
 %.elc: %.el
@@ -7,16 +7,22 @@ RM      ?= rm -f
 
 all: lisp
 
+.PHONY: help
 help:
-	$(info Available options)
-	$(info - clean   : Clean the build directory)
-	$(info - emacs-Q : Launch emacs -Q with Hackernews loaded)
-	$(info - lisp    : Byte-compile Elisp sources)
+	$(info Available targets)
+	$(info )
+	$(info [all]     Same as 'lisp' (default))
+	$(info clean     Clean the build directory)
+	$(info emacs-Q   Launch emacs -Q with Hackernews loaded)
+	$(info lisp      Byte-compile Elisp sources)
+	@:
 
+.PHONY: emacs-Q
 emacs-Q:
 	$(EMACS) --quick --load=$(PACKAGE).el
 
 lisp: $(PACKAGE).elc
 
+.PHONY: clean
 clean:
 	$(RM) $(PACKAGE).elc

--- a/hackernews-pkg.el
+++ b/hackernews-pkg.el
@@ -1,3 +1,0 @@
-(define-package "hackernews" "0.5.0"
-  "Access the Hacker News aggregator from Emacs"
-  '((json "1.2")))


### PR DESCRIPTION
* Remove target `package` and generated file `hackernews-pkg.el`.
* Add build and launch targets `lisp` and `emacs-Q`, respectively.
* Improve usage documentation.
* Specify phony targets.

Re: #57.